### PR TITLE
Add a script to generate testing GitHub Actions workflow & convert to parallel jobs

### DIFF
--- a/.github/workflows/push-build-test-on-push.yml
+++ b/.github/workflows/push-build-test-on-push.yml
@@ -2,78 +2,6 @@
 'on': push
 name: Build & test on push
 jobs:
-  Test_checkup:
-    name: Test checkup
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v2
-    - name: Test checkup
-      uses: parkr/actions/docker-make@main
-      with:
-        args: test-checkup
-  Test_homeassistant:
-    name: Test homeassistant
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v2
-    - name: Test homeassistant
-      uses: parkr/actions/docker-make@main
-      with:
-        args: test-homeassistant
-  Test_monicahq:
-    name: Test monicahq
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v2
-    - name: Test monicahq
-      uses: parkr/actions/docker-make@main
-      with:
-        args: test-monicahq
-  Test_rclone:
-    name: Test rclone
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v2
-    - name: Test rclone
-      uses: parkr/actions/docker-make@main
-      with:
-        args: test-rclone
-  Test_southwestcheckin:
-    name: Test southwestcheckin
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v2
-    - name: Test southwestcheckin
-      uses: parkr/actions/docker-make@main
-      with:
-        args: test-southwestcheckin
-  Test_octodns:
-    name: Test octodns
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v2
-    - name: Test octodns
-      uses: parkr/actions/docker-make@main
-      with:
-        args: test-octodns
-  Test_silence-but-for-error:
-    name: Test silence-but-for-error
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v2
-    - name: Test silence-but-for-error
-      uses: parkr/actions/docker-make@main
-      with:
-        args: test-silence-but-for-error
-  Test_curl:
-    name: Test curl
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v2
-    - name: Test curl
-      uses: parkr/actions/docker-make@main
-      with:
-        args: test-curl
   Test_airconnect:
     name: Test airconnect
     runs-on: ubuntu-latest
@@ -92,15 +20,24 @@ jobs:
       uses: parkr/actions/docker-make@main
       with:
         args: test-aws-cli
-  Test_graphql-schema-linter:
-    name: Test graphql-schema-linter
+  Test_checkup:
+    name: Test checkup
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - name: Test graphql-schema-linter
+    - name: Test checkup
       uses: parkr/actions/docker-make@main
       with:
-        args: test-graphql-schema-linter
+        args: test-checkup
+  Test_curl:
+    name: Test curl
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Test curl
+      uses: parkr/actions/docker-make@main
+      with:
+        args: test-curl
   Test_git:
     name: Test git
     runs-on: ubuntu-latest
@@ -110,6 +47,42 @@ jobs:
       uses: parkr/actions/docker-make@main
       with:
         args: test-git
+  Test_graphql-schema-linter:
+    name: Test graphql-schema-linter
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Test graphql-schema-linter
+      uses: parkr/actions/docker-make@main
+      with:
+        args: test-graphql-schema-linter
+  Test_homeassistant:
+    name: Test homeassistant
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Test homeassistant
+      uses: parkr/actions/docker-make@main
+      with:
+        args: test-homeassistant
+  Test_monicahq:
+    name: Test monicahq
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Test monicahq
+      uses: parkr/actions/docker-make@main
+      with:
+        args: test-monicahq
+  Test_octodns:
+    name: Test octodns
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Test octodns
+      uses: parkr/actions/docker-make@main
+      with:
+        args: test-octodns
   Test_puppet-lint:
     name: Test puppet-lint
     runs-on: ubuntu-latest
@@ -119,3 +92,30 @@ jobs:
       uses: parkr/actions/docker-make@main
       with:
         args: test-puppet-lint
+  Test_rclone:
+    name: Test rclone
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Test rclone
+      uses: parkr/actions/docker-make@main
+      with:
+        args: test-rclone
+  Test_silence-but-for-error:
+    name: Test silence-but-for-error
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Test silence-but-for-error
+      uses: parkr/actions/docker-make@main
+      with:
+        args: test-silence-but-for-error
+  Test_southwestcheckin:
+    name: Test southwestcheckin
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Test southwestcheckin
+      uses: parkr/actions/docker-make@main
+      with:
+        args: test-southwestcheckin

--- a/.github/workflows/push-build-test-on-push.yml
+++ b/.github/workflows/push-build-test-on-push.yml
@@ -2,7 +2,7 @@
 'on': push
 name: Build & test on push
 jobs:
-  Test checkup:
+  Test_checkup:
     name: Test checkup
     runs-on: ubuntu-latest
     steps:
@@ -11,7 +11,7 @@ jobs:
       uses: parkr/actions/docker-make@main
       with:
         args: test-checkup
-  Test homeassistant:
+  Test_homeassistant:
     name: Test homeassistant
     runs-on: ubuntu-latest
     steps:
@@ -20,7 +20,7 @@ jobs:
       uses: parkr/actions/docker-make@main
       with:
         args: test-homeassistant
-  Test monicahq:
+  Test_monicahq:
     name: Test monicahq
     runs-on: ubuntu-latest
     steps:
@@ -29,7 +29,7 @@ jobs:
       uses: parkr/actions/docker-make@main
       with:
         args: test-monicahq
-  Test rclone:
+  Test_rclone:
     name: Test rclone
     runs-on: ubuntu-latest
     steps:
@@ -38,7 +38,7 @@ jobs:
       uses: parkr/actions/docker-make@main
       with:
         args: test-rclone
-  Test southwestcheckin:
+  Test_southwestcheckin:
     name: Test southwestcheckin
     runs-on: ubuntu-latest
     steps:
@@ -47,7 +47,7 @@ jobs:
       uses: parkr/actions/docker-make@main
       with:
         args: test-southwestcheckin
-  Test octodns:
+  Test_octodns:
     name: Test octodns
     runs-on: ubuntu-latest
     steps:
@@ -56,7 +56,7 @@ jobs:
       uses: parkr/actions/docker-make@main
       with:
         args: test-octodns
-  Test silence-but-for-error:
+  Test_silence-but-for-error:
     name: Test silence-but-for-error
     runs-on: ubuntu-latest
     steps:
@@ -65,7 +65,7 @@ jobs:
       uses: parkr/actions/docker-make@main
       with:
         args: test-silence-but-for-error
-  Test curl:
+  Test_curl:
     name: Test curl
     runs-on: ubuntu-latest
     steps:
@@ -74,7 +74,7 @@ jobs:
       uses: parkr/actions/docker-make@main
       with:
         args: test-curl
-  Test airconnect:
+  Test_airconnect:
     name: Test airconnect
     runs-on: ubuntu-latest
     steps:
@@ -83,7 +83,7 @@ jobs:
       uses: parkr/actions/docker-make@main
       with:
         args: test-airconnect
-  Test aws-cli:
+  Test_aws-cli:
     name: Test aws-cli
     runs-on: ubuntu-latest
     steps:
@@ -92,7 +92,7 @@ jobs:
       uses: parkr/actions/docker-make@main
       with:
         args: test-aws-cli
-  Test graphql-schema-linter:
+  Test_graphql-schema-linter:
     name: Test graphql-schema-linter
     runs-on: ubuntu-latest
     steps:
@@ -101,7 +101,7 @@ jobs:
       uses: parkr/actions/docker-make@main
       with:
         args: test-graphql-schema-linter
-  Test git:
+  Test_git:
     name: Test git
     runs-on: ubuntu-latest
     steps:
@@ -110,7 +110,7 @@ jobs:
       uses: parkr/actions/docker-make@main
       with:
         args: test-git
-  Test puppet-lint:
+  Test_puppet-lint:
     name: Test puppet-lint
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/push-build-test-on-push.yml
+++ b/.github/workflows/push-build-test-on-push.yml
@@ -1,60 +1,121 @@
-on: push
+---
+'on': push
 name: Build & test on push
 jobs:
-  TestAll:
-    name: Test All
+  Test checkup:
+    name: Test checkup
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@master
-    - name: Test southwestcheckin
-      uses: parkr/actions/docker-make@main
-      with:
-        args: test-southwestcheckin
-    - name: Test silence-but-for-error
-      uses: parkr/actions/docker-make@main
-      with:
-        args: test-silence-but-for-error
-    - name: Test rclone
-      uses: parkr/actions/docker-make@main
-      with:
-        args: test-rclone
-    - name: Test puppet-lint
-      uses: parkr/actions/docker-make@main
-      with:
-        args: test-puppet-lint
-    - name: Test octodns
-      uses: parkr/actions/docker-make@main
-      with:
-        args: test-octodns
-    - name: Test monicahq
-      uses: parkr/actions/docker-make@main
-      with:
-        args: test-monicahq
-    - name: Test homeassistant
-      uses: parkr/actions/docker-make@main
-      with:
-        args: test-homeassistant
-    - name: Test graphql-schema-linter
-      uses: parkr/actions/docker-make@main
-      with:
-        args: test-graphql-schema-linter
-    - name: Test git
-      uses: parkr/actions/docker-make@main
-      with:
-        args: test-git
-    - name: Test curl
-      uses: parkr/actions/docker-make@main
-      with:
-        args: test-curl
+    - uses: actions/checkout@v2
     - name: Test checkup
       uses: parkr/actions/docker-make@main
       with:
         args: test-checkup
-    - name: Test aws-cli
+  Test homeassistant:
+    name: Test homeassistant
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Test homeassistant
       uses: parkr/actions/docker-make@main
       with:
-        args: test-aws-cli
+        args: test-homeassistant
+  Test monicahq:
+    name: Test monicahq
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Test monicahq
+      uses: parkr/actions/docker-make@main
+      with:
+        args: test-monicahq
+  Test rclone:
+    name: Test rclone
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Test rclone
+      uses: parkr/actions/docker-make@main
+      with:
+        args: test-rclone
+  Test southwestcheckin:
+    name: Test southwestcheckin
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Test southwestcheckin
+      uses: parkr/actions/docker-make@main
+      with:
+        args: test-southwestcheckin
+  Test octodns:
+    name: Test octodns
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Test octodns
+      uses: parkr/actions/docker-make@main
+      with:
+        args: test-octodns
+  Test silence-but-for-error:
+    name: Test silence-but-for-error
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Test silence-but-for-error
+      uses: parkr/actions/docker-make@main
+      with:
+        args: test-silence-but-for-error
+  Test curl:
+    name: Test curl
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Test curl
+      uses: parkr/actions/docker-make@main
+      with:
+        args: test-curl
+  Test airconnect:
+    name: Test airconnect
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
     - name: Test airconnect
       uses: parkr/actions/docker-make@main
       with:
         args: test-airconnect
+  Test aws-cli:
+    name: Test aws-cli
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Test aws-cli
+      uses: parkr/actions/docker-make@main
+      with:
+        args: test-aws-cli
+  Test graphql-schema-linter:
+    name: Test graphql-schema-linter
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Test graphql-schema-linter
+      uses: parkr/actions/docker-make@main
+      with:
+        args: test-graphql-schema-linter
+  Test git:
+    name: Test git
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Test git
+      uses: parkr/actions/docker-make@main
+      with:
+        args: test-git
+  Test puppet-lint:
+    name: Test puppet-lint
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Test puppet-lint
+      uses: parkr/actions/docker-make@main
+      with:
+        args: test-puppet-lint

--- a/script/build-github-actions
+++ b/script/build-github-actions
@@ -17,6 +17,8 @@ Dir.foreach(root_dir) do |path|
   projects << path
 end
 
+projects.sort!
+
 def generate_jobs(projects, name:, make_prefix:)
   projects.each_with_object({}) do |project_name, memo|
     memo["#{name}_#{project_name}"] = {

--- a/script/build-github-actions
+++ b/script/build-github-actions
@@ -19,7 +19,7 @@ end
 
 def generate_jobs(projects, name:, make_prefix:)
   projects.each_with_object({}) do |project_name, memo|
-    memo["#{name} #{project_name}"] = {
+    memo["#{name}_#{project_name}"] = {
       "name" => "#{name} #{project_name}",
       "runs-on" => "ubuntu-latest",
       "steps" => [

--- a/script/build-github-actions
+++ b/script/build-github-actions
@@ -1,0 +1,43 @@
+#!/usr/bin/env ruby
+#/ Usage: script/build-github-actions
+#/ Build the GitHub Actions YAML workflows for this directory.
+#/ Run this any time you add new docker images.
+
+require "yaml"
+
+root_dir = File.expand_path("..", __dir__)
+
+projects = []
+
+Dir.foreach(root_dir) do |path|
+  next unless File.directory?(path)
+  next if path.start_with?(".")
+  next unless File.file?(File.join(path, "Dockerfile"))
+
+  projects << path
+end
+
+def generate_jobs(projects, name:, make_prefix:)
+  projects.each_with_object({}) do |project_name, memo|
+    memo["#{name} #{project_name}"] = {
+      "name" => "#{name} #{project_name}",
+      "runs-on" => "ubuntu-latest",
+      "steps" => [
+        {"uses" => "actions/checkout@v2"},
+        {
+          "name" => "#{name} #{project_name}",
+          "uses" => "parkr/actions/docker-make@main",
+          "with" => {"args" => "#{make_prefix}-#{project_name}"},
+        }
+      ]
+    }
+  end
+end
+
+File.open(File.expand_path(".github/workflows/push-build-test-on-push.yml", root_dir), "wb") do |f|
+  f.puts YAML.dump({
+    "on" => "push",
+    "name" => "Build & test on push",
+    "jobs" => generate_jobs(projects, name: "Test", make_prefix: "test")
+  })
+end


### PR DESCRIPTION
In an effort to get quicker results (currently about 11 min for `Test All` to return).

The setup process is only ~15s to checkout the code and to to make the docker-make step available.