### PR TITLE
checkup: git clone source repo

### DIFF
--- a/checkup/Dockerfile
+++ b/checkup/Dockerfile
@@ -3,12 +3,11 @@ ARG VERSION
 RUN set -ex \
     && apk add --no-cache git
 ENV CHECKOUT_DIR /go/src/github.com/sourcegraph/checkup
+RUN git clone https://github.com/sourcegraph/checkup ${CHECKOUT_DIR}
+WORKDIR $CHECKOUT_DIR
 RUN set -ex \
-    && git clone https://github.com/sourcegraph/checkup ${CHECKOUT_DIR} \
-    && cd ${CHECKOUT_DIR} \
     && git checkout -q $VERSION \
     && [ "$(git --work-tree=$CHECKOUT_DIR --git-dir=$CHECKOUT_DIR/.git rev-parse HEAD)" = $VERSION ] \
-    && go mod download \
     && go version \
     && GOOS=linux go install -v -ldflags "-w -s" github.com/sourcegraph/checkup/...
 

--- a/checkup/Dockerfile
+++ b/checkup/Dockerfile
@@ -4,9 +4,11 @@ RUN set -ex \
     && apk add --no-cache git
 ENV CHECKOUT_DIR /go/src/github.com/sourcegraph/checkup
 RUN set -ex \
-    && go get -d github.com/sourcegraph/checkup/... \
-    && git --work-tree=$CHECKOUT_DIR --git-dir=$CHECKOUT_DIR/.git checkout -q $VERSION \
-    && [  "$(git --work-tree=$CHECKOUT_DIR --git-dir=$CHECKOUT_DIR/.git rev-parse HEAD)" = $VERSION ] \
+    && git clone https://github.com/sourcegraph/checkup ${CHECKOUT_DIR} \
+    && pushd ${CHECKOUT_DIR} \
+    && git checkout -q $VERSION \
+    && [ "$(git --work-tree=$CHECKOUT_DIR --git-dir=$CHECKOUT_DIR/.git rev-parse HEAD)" = $VERSION ] \
+    && go mod download \
     && go version \
     && GOOS=linux go install -v -ldflags "-w -s" github.com/sourcegraph/checkup/...
 

--- a/checkup/Dockerfile
+++ b/checkup/Dockerfile
@@ -5,7 +5,7 @@ RUN set -ex \
 ENV CHECKOUT_DIR /go/src/github.com/sourcegraph/checkup
 RUN set -ex \
     && git clone https://github.com/sourcegraph/checkup ${CHECKOUT_DIR} \
-    && pushd ${CHECKOUT_DIR} \
+    && cd ${CHECKOUT_DIR} \
     && git checkout -q $VERSION \
     && [ "$(git --work-tree=$CHECKOUT_DIR --git-dir=$CHECKOUT_DIR/.git rev-parse HEAD)" = $VERSION ] \
     && go mod download \


### PR DESCRIPTION
Go get now uses the Go Modules Proxy which doesn't have Git info.