### PR TITLE
rclone: allow latest_version.sh to be run from anywhere

### DIFF
--- a/.github/workflows/update-automatically.yml
+++ b/.github/workflows/update-automatically.yml
@@ -15,7 +15,7 @@ jobs:
        uses: technote-space/create-pr-action@v2
        with:
          EXECUTE_COMMANDS: |
-           cd rclone && bash latest_version.sh
+           bash rclone/latest_version.sh
          COMMIT_MESSAGE: 'update rclone version'
          COMMIT_NAME: 'GitHub Actions'
          COMMIT_EMAIL: 'actions@github.com'

--- a/rclone/latest_version.sh
+++ b/rclone/latest_version.sh
@@ -1,4 +1,12 @@
 #!/bin/bash
 
+set -ex
+
+current_dir="$( cd "$(dirname "$0")" ; pwd -P )"
+version_file_path="${current_dir}/VERSION"
+echo "$version_file_path"
+
 # 'rclone vx.y.z'
-curl https://downloads.rclone.org/version.txt | awk '{print $2}' > VERSION
+curl https://downloads.rclone.org/version.txt | awk '{print $2}' > "$version_file_path"
+
+cat "$version_file_path"


### PR DESCRIPTION
Can hopefully fix these errors: https://github.com/parkr/dockerfiles/runs/3864916846?check_suite_focus=true