### PR TITLE
yt-dlp: use the python version, not the executable

### DIFF
--- a/yt-dlp/Dockerfile
+++ b/yt-dlp/Dockerfile
@@ -1,12 +1,11 @@
 FROM parkr/curl:latest
 WORKDIR /yt-dlp
 RUN set -ex \
-    && apk add --no-cache python3 \
+    && apk add --no-cache python3 ffmpeg \
     && rm -rf /var/cache/apk/* /etc/apk/* /lib/apk/* /usr/share/apk/*
 ARG VERSION
 RUN curl -sLf \
     -o /usr/local/bin/yt-dlp \
     "https://github.com/yt-dlp/yt-dlp/releases/download/${VERSION}/yt-dlp" \
   && chmod 755 /usr/local/bin/yt-dlp
-RUN apk update && apk upgrade && apk add --no-cache ffmpeg
 ENTRYPOINT [ "/usr/local/bin/yt-dlp" ]

--- a/yt-dlp/Dockerfile
+++ b/yt-dlp/Dockerfile
@@ -1,11 +1,12 @@
 FROM parkr/curl:latest
 WORKDIR /yt-dlp
-COPY yt-dlp-artifact-suffix.sh .
+RUN set -ex \
+    && apk add --no-cache python3 \
+    && rm -rf /var/cache/apk/* /etc/apk/* /lib/apk/* /usr/share/apk/*
 ARG VERSION
-RUN SUFFIX="$(bash yt-dlp-artifact-suffix.sh)" \
-  && curl -sLf \
+RUN curl -sLf \
     -o /usr/local/bin/yt-dlp \
-    "https://github.com/yt-dlp/yt-dlp/releases/download/${VERSION}/yt-dlp_linux${SUFFIX}" \
+    "https://github.com/yt-dlp/yt-dlp/releases/download/${VERSION}/yt-dlp" \
   && chmod 755 /usr/local/bin/yt-dlp
 RUN apk update && apk upgrade && apk add --no-cache ffmpeg
 ENTRYPOINT [ "/usr/local/bin/yt-dlp" ]


### PR DESCRIPTION
It's not statically compiled so it requires libc .so file which is not available in Alpine linux.