### PR TITLE
puppet-lint: fix ruby-json being removed

### DIFF
--- a/puppet-lint/Dockerfile
+++ b/puppet-lint/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine:latest
 RUN set -ex \
-    && apk add --no-cache ruby ruby-json ruby-bundler ruby-dev \
+    && apk add --no-cache ruby ruby-bundler ruby-dev \
     && rm -rf /var/cache/apk/* /etc/apk/* /lib/apk/* /usr/share/apk/*
 ARG VERSION
 RUN gem install puppet-lint --no-document -v $VERSION


### PR DESCRIPTION
https://perrotta.dev/2025/06/alpine-linux-package-is-gone/